### PR TITLE
Update pom.xml to point correct sourceDirectory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,20 +23,14 @@
   </licenses>
 
   <build>
-    <sourceDirectory>src/main/</sourceDirectory>
-    <outputDirectory>target/classes</outputDirectory>
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.2</version>
+        <version>2.0</version>
         <configuration>
           <source>1.5</source>
           <target>1.5</target>
         </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>2.3</version>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
No need to specify sourceDirectory if the project follows maven
standard. With the fix, I removed unnecessary definitions for
maven-compiler-plugin.

I guess this wrong definitions are from my temporary pom.xml definition.
Sorry for confusing!
