### PR TITLE
Handle unwrapped (header/checkless) streams

### DIFF
--- a/src/test/scala/DeflaterInflaterStreamTest.scala
+++ b/src/test/scala/DeflaterInflaterStreamTest.scala
@@ -45,10 +45,10 @@ class DeflaterInflaterStreamTest {
 
     List(true, false).foreach { nowrap =>
     (1 to 100 by 3).foreach { i =>
-
+    List(randombuf(10240), 
+         "{\"color\":2,\"id\":\"EvLd4UG.CXjnk35o1e8LrYYQfHu0h.d*SqVJPoqmzXM::Ly::Snaps::Store::Commit\"}".getBytes).foreach { data1 =>
+                              
       val buf = new Array[Byte](i)
-
-      val data1 = randombuf(10240)
 
       val baos = new ByteArrayOutputStream
       val gos = new DeflaterOutputStream(baos,
@@ -74,6 +74,7 @@ class DeflaterInflaterStreamTest {
 
       assertThat(data2.length, is(data1.length))
       assertThat(data2, is(data1))
+    }
     }
     }
   }

--- a/src/test/scala/DeflaterInflaterStreamTest.scala
+++ b/src/test/scala/DeflaterInflaterStreamTest.scala
@@ -41,8 +41,9 @@ class DeflaterInflaterStreamTest {
   }
 
   @Test
-  def read_writh_with_buf = {
+  def read_write_with_buf = {
 
+    List(true, false).foreach { nowrap =>
     (1 to 100 by 3).foreach { i =>
 
       val buf = new Array[Byte](i)
@@ -50,7 +51,10 @@ class DeflaterInflaterStreamTest {
       val data1 = randombuf(10240)
 
       val baos = new ByteArrayOutputStream
-      val gos = new DeflaterOutputStream(baos)
+      val gos = new DeflaterOutputStream(baos,
+                                         new Deflater(JZlib.Z_DEFAULT_COMPRESSION,
+                                                      JZlib.MAX_WBITS,
+                                                      nowrap))
 
       val datai = new ByteArrayInputStream(data1)
       Stream.continually(datai.read(buf)).
@@ -59,7 +63,7 @@ class DeflaterInflaterStreamTest {
       datai.close
 
       val bais = new ByteArrayInputStream(baos.toByteArray)
-      val gis = new InflaterInputStream(bais)
+      val gis = new InflaterInputStream(bais, new Inflater(JZlib.MAX_WBITS, nowrap))
 
       val baos2 = new ByteArrayOutputStream
 
@@ -70,6 +74,7 @@ class DeflaterInflaterStreamTest {
 
       assertThat(data2.length, is(data1.length))
       assertThat(data2, is(data1))
+    }
     }
   }
 


### PR DESCRIPTION
Current stream inflate code doesn't handle unwrapped data. zlib doesn't provide Z_STREAM_END in this case. It also consumes the whole input stream immediately and the current stream loop code relies on the fact that the check (which doesn't exist in the unrwapped case) doesn't get consumed until the data has been written to the output stream when the data is not unwrapped.

Can be demonstrated pretty easily by using the existing read_write_with_buf test and running it unwrapped, which is in the patch.

The fix is fairly simple (though it did take a while to track down.) Simply separate the concepts of eof on the input stream from finished state of the inflater.

I didn't muck with the indentation in read_write_with_buf so that the diff would be smipler to compare.
