### PR TITLE
improving error diagnosis.

### DIFF
--- a/src/main/java/com/jcraft/jzlib/DeflaterOutputStream.java
+++ b/src/main/java/com/jcraft/jzlib/DeflaterOutputStream.java
@@ -137,7 +137,7 @@ public class DeflaterOutputStream extends FilterOutputStream {
           break;
         }
       default:
-        throw new IOException("failed to deflate");
+        throw new IOException("failed to deflate: error="+err+" avail_out="+deflater.avail_out);
     }
     int len = deflater.next_out_index;
     if (len > 0) {


### PR DESCRIPTION
This is done to better understand reported problems such as https://issues.jenkins-ci.org/browse/JENKINS-20618 and https://issues.jenkins-ci.org/browse/JENKINS-20114 where jzlib can be seen mysteriously failing.
