### PR TITLE
Fixed a bug that made GZIPInputStream.getModifiedtime always return 0

### DIFF
--- a/src/main/java/com/jcraft/jzlib/GZIPHeader.java
+++ b/src/main/java/com/jcraft/jzlib/GZIPHeader.java
@@ -59,7 +59,6 @@ public class GZIPHeader implements Cloneable {
 
   boolean text = false;
   private boolean fhcrc = false;
-  long time;
   int xflags;
   int os = 255;
   byte[] extra;

--- a/src/main/java/com/jcraft/jzlib/Inflate.java
+++ b/src/main/java/com/jcraft/jzlib/Inflate.java
@@ -455,7 +455,7 @@ final class Inflate{
         try { r=readBytes(4, r, f); }
         catch(Return e){ return e.r; }
         if(gheader!=null)
-          gheader.time = this.need;
+          gheader.setModifiedTime(this.need);
         if ((flags & 0x0200)!=0){
           checksum(4, this.need);
         }

--- a/src/test/scala/GZIPIOStreamTest.scala
+++ b/src/test/scala/GZIPIOStreamTest.scala
@@ -26,6 +26,7 @@ class GZIPIOStreamTest extends FlatSpec with BeforeAndAfter with ShouldMatchers 
 
     val comment = "hi"
     val name = "/tmp/foo"
+    val mtime = 0x11223344
 
     val content = "hello".getBytes
 
@@ -34,6 +35,7 @@ class GZIPIOStreamTest extends FlatSpec with BeforeAndAfter with ShouldMatchers 
 
     gos.setComment(comment)
     gos.setName(name)
+    gos.setModifiedTime(mtime)
  
     gos.write(content)
     gos.close
@@ -51,6 +53,7 @@ class GZIPIOStreamTest extends FlatSpec with BeforeAndAfter with ShouldMatchers 
 
     comment should equal(gis.getComment)
     name should equal(gis.getName)
+    mtime should equal(gis.getModifiedtime)
 
     val crc32 = new CRC32
     crc32.update(content, 0, content.length)


### PR DESCRIPTION
GZIPInputStream.getModifiedtime always returns 0 because Inflate.java was writing directly to GZIPHeader.time, which is different from GZIPHeader.mtime and not actually used.  This pull request adds a test, fixes the bug, and gets rid of the unused 'time' member in GZIPHeader.

Separately, shouldn't the name of that function actually be getModifiedTime  with a capital T on Time?
