### PR TITLE
Fix errors preventing javadoc generation on Java 8

### DIFF
--- a/src/main/java/com/jcraft/jzlib/GZIPHeader.java
+++ b/src/main/java/com/jcraft/jzlib/GZIPHeader.java
@@ -37,7 +37,7 @@ package com.jcraft.jzlib;
 import java.io.UnsupportedEncodingException;
 
 /**
- * @see "http://www.ietf.org/rfc/rfc1952.txt"
+ * See "http://www.ietf.org/rfc/rfc1952.txt"
  */
 public class GZIPHeader implements Cloneable {
 

--- a/src/main/java/com/jcraft/jzlib/ZStream.java
+++ b/src/main/java/com/jcraft/jzlib/ZStream.java
@@ -371,6 +371,8 @@ public class ZStream{
   /**
    * Those methods are expected to be override by Inflater and Deflater.
    * In the future, they will become abstract methods.
+   *
+   * @return an error code
    */ 
   public int end(){ return Z_OK; }
   public boolean finished(){ return false; }


### PR DESCRIPTION
Javadoc generation using Java 8 is now much more strict by default than it was in earlier Java versions, which means that javadocs fail to be generated when executing **mvn javadoc:aggregate** using a Java 8 JDK. For example:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:2.9.1:aggregate (default-cli) on project jzlib: An error has occurred in JavaDocs report generation:
[ERROR] Exit code: 1 - /home/mbooth/git/jzlib/src/main/java/com/jcraft/jzlib/ZStream.java:375: warning: no @return
[ERROR] public int end(){ return Z_OK; }
[ERROR] ^
[ERROR] /home/mbooth/git/jzlib/src/main/java/com/jcraft/jzlib/GZIPHeader.java:40: error: unexpected content
[ERROR] * @see "http://www.ietf.org/rfc/rfc1952.txt"
[ERROR] ^
[ERROR] 
[ERROR] Command line was: /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.5.x86_64/jre/../bin/javadoc @options @packages
```

The change in this pull request fixes the minor errors in the javadoc comments and enables javadoc generation to succeed under Java 8.
