### PR TITLE
Concatenated gzip streams

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,5 @@
+Note: This version of jzlib has been taken over by the JRuby team due
+to the lack of maintenance of the original project.
 
                                      JZlib
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,17 @@
     <url>http://www.jcraft.com/</url>
   </organization>
 
+  <issueManagement>
+    <system>GitHub</system>
+    <url>https://github.com/jruby/jzlib/issues</url>
+  </issueManagement>
+
+  <scm>
+    <connection>scm:git:https://github.com/jruby/jzlib.git</connection>
+    <developerConnection>scm:git:git@github.com:jruby/jzlib.git</developerConnection>
+    <url>https://github.com/jruby/jzlib</url>
+  </scm>
+
   <licenses>
     <license>
       <name>BSD</name>
@@ -32,7 +43,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.0</version>
+        <version>3.8.0</version>
         <configuration>
           <source>7</source>
           <target>7</target>

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.jruby</groupId>
   <artifactId>jzlib</artifactId>
-  <version>1.1.4-SNAPSHOT</version>
+  <version>1.1.4</version>
   <name>JZlib</name>
   <description>JZlib is a re-implementation of zlib in pure Java</description>
   <url>http://www.jcraft.com/jzlib/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.jruby</groupId>
   <artifactId>jzlib</artifactId>
-  <version>1.1.4</version>
+  <version>1.1.5-SNAPSHOT</version>
   <name>JZlib</name>
   <description>JZlib is a re-implementation of zlib in pure Java</description>
   <url>http://www.jcraft.com/jzlib/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,18 @@
           <optimize>true</optimize>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.2.0</version>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.jruby.jzlib</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,9 +3,9 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>com.jcraft</groupId>
+  <groupId>org.jruby</groupId>
   <artifactId>jzlib</artifactId>
-  <version>1.1.3</version>
+  <version>1.1.4-SNAPSHOT</version>
   <name>JZlib</name>
   <description>JZlib is a re-implementation of zlib in pure Java</description>
   <url>http://www.jcraft.com/jzlib/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.0</version>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>7</source>
+          <target>7</target>
           <optimize>true</optimize>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,12 @@
   <description>JZlib is a re-implementation of zlib in pure Java</description>
   <url>http://www.jcraft.com/jzlib/</url>
 
+  <parent>
+    <groupId>org.sonatype.oss</groupId>
+    <artifactId>oss-parent</artifactId>
+    <version>7</version>
+  </parent>
+
   <organization>
     <name>jcraft</name>
     <url>http://www.jcraft.com/</url>

--- a/src/main/java/com/jcraft/jzlib/GZIPHeader.java
+++ b/src/main/java/com/jcraft/jzlib/GZIPHeader.java
@@ -59,7 +59,6 @@ public class GZIPHeader implements Cloneable {
 
   boolean text = false;
   private boolean fhcrc = false;
-  long time;
   int xflags;
   int os = 255;
   byte[] extra;

--- a/src/main/java/com/jcraft/jzlib/GZIPHeader.java
+++ b/src/main/java/com/jcraft/jzlib/GZIPHeader.java
@@ -37,7 +37,7 @@ package com.jcraft.jzlib;
 import java.io.UnsupportedEncodingException;
 
 /**
- * @see "http://www.ietf.org/rfc/rfc1952.txt"
+ * @see <a href="http://www.ietf.org/rfc/rfc1952.txt">http://www.ietf.org/rfc/rfc1952.txt</a>
  */
 public class GZIPHeader implements Cloneable {
 

--- a/src/main/java/com/jcraft/jzlib/GZIPInputStream.java
+++ b/src/main/java/com/jcraft/jzlib/GZIPInputStream.java
@@ -50,6 +50,25 @@ public class GZIPInputStream extends InflaterInputStream {
     super(in, inflater, size, close_in);
   }
 
+  public int read(byte[] b, int off, int len) throws IOException {
+    int i = super.read(b, off, len);
+    if(i == -1){
+      if(inflater.avail_in<2){
+        int l = in.read(buf, 0, buf.length);
+        if(l>0)
+          inflater.setInput(buf, 0, l, true);
+      }
+      if(inflater.avail_in>2 &&
+         ((inflater.next_in[inflater.next_in_index]&0xff) == 0x1f) &&
+         ((inflater.next_in[inflater.next_in_index+1]&0xff) == (0x8b&0xff))){
+        this.inflater.reset();
+        this.eof=false;
+        return super.read(b, off, len);
+      }
+    } 
+    return i;
+  }
+
   /**
    * @deprecated use getModifiedTime()
    * @return long modified time.

--- a/src/main/java/com/jcraft/jzlib/GZIPInputStream.java
+++ b/src/main/java/com/jcraft/jzlib/GZIPInputStream.java
@@ -69,7 +69,17 @@ public class GZIPInputStream extends InflaterInputStream {
     return i;
   }
 
+  /**
+   * @deprecated use getModifiedTime()
+   */
   public long getModifiedtime() {
+    return this.getModifiedTime();
+  }
+
+  /**
+   * @return the modified time.
+   */
+  public long getModifiedTime() {
     return inflater.istate.getGZIPHeader().getModifiedTime();
   }
 

--- a/src/main/java/com/jcraft/jzlib/GZIPInputStream.java
+++ b/src/main/java/com/jcraft/jzlib/GZIPInputStream.java
@@ -50,25 +50,6 @@ public class GZIPInputStream extends InflaterInputStream {
     super(in, inflater, size, close_in);
   }
 
-  public int read(byte[] b, int off, int len) throws IOException {
-    int i = super.read(b, off, len);
-    if(i == -1){
-      if(inflater.avail_in<2){
-        int l = in.read(buf, 0, buf.length);
-        if(l>0)
-          inflater.setInput(buf, 0, l, true);
-      }
-      if(inflater.avail_in>2 &&
-         ((inflater.next_in[inflater.next_in_index]&0xff) == 0x1f) &&
-         ((inflater.next_in[inflater.next_in_index+1]&0xff) == (0x8b&0xff))){
-        this.inflater.reset();
-        this.eof=false;
-        return super.read(b, off, len);
-      }
-    } 
-    return i;
-  }
-
   /**
    * @deprecated use getModifiedTime()
    * @return long modified time.

--- a/src/main/java/com/jcraft/jzlib/GZIPInputStream.java
+++ b/src/main/java/com/jcraft/jzlib/GZIPInputStream.java
@@ -50,6 +50,25 @@ public class GZIPInputStream extends InflaterInputStream {
     super(in, inflater, size, close_in);
   }
 
+  public int read(byte[] b, int off, int len) throws IOException {
+    int i = super.read(b, off, len);
+    if(i == -1){
+      if(inflater.avail_in<2){
+        int l = in.read(buf, 0, buf.length);
+        if(l>0)
+          inflater.setInput(buf, 0, l, true);
+      }
+      if(inflater.avail_in>2 &&
+         ((inflater.next_in[inflater.next_in_index]&0xff) == 0x1f) &&
+         ((inflater.next_in[inflater.next_in_index+1]&0xff) == (0x8b&0xff))){
+        this.inflater.reset();
+        this.eof=false;
+        return super.read(b, off, len);
+      }
+    } 
+    return i;
+  }
+
   public long getModifiedtime() {
     return inflater.istate.getGZIPHeader().getModifiedTime();
   }

--- a/src/main/java/com/jcraft/jzlib/GZIPInputStream.java
+++ b/src/main/java/com/jcraft/jzlib/GZIPInputStream.java
@@ -71,6 +71,7 @@ public class GZIPInputStream extends InflaterInputStream {
 
   /**
    * @deprecated use getModifiedTime()
+   * @return long modified time.
    */
   public long getModifiedtime() {
     return this.getModifiedTime();

--- a/src/main/java/com/jcraft/jzlib/Inflate.java
+++ b/src/main/java/com/jcraft/jzlib/Inflate.java
@@ -454,8 +454,9 @@ final class Inflate{
       case TIME:
         try { r=readBytes(4, r, f); }
         catch(Return e){ return e.r; }
-        if(gheader!=null)
-          gheader.time = this.need;
+        if(gheader!=null){
+          gheader.setModifiedTime(this.need);
+        }
         if ((flags & 0x0200)!=0){
           checksum(4, this.need);
         }

--- a/src/main/java/com/jcraft/jzlib/Inflater.java
+++ b/src/main/java/com/jcraft/jzlib/Inflater.java
@@ -57,6 +57,10 @@ final public class Inflater extends ZStream{
   static final private int Z_BUF_ERROR=-5;
   static final private int Z_VERSION_ERROR=-6;
 
+  private int param_w = -1;
+  private JZlib.WrapperType param_wrapperType = null;
+  private boolean param_nowrap = false;
+
   public Inflater() {
     super();
     init();
@@ -68,6 +72,8 @@ final public class Inflater extends ZStream{
 
   public Inflater(int w, JZlib.WrapperType wrapperType) throws GZIPException {
     super();
+    param_w = w;
+    param_wrapperType = wrapperType;
     int ret = init(w, wrapperType);
     if(ret!=Z_OK)
       throw new GZIPException(ret+": "+msg);
@@ -83,9 +89,21 @@ final public class Inflater extends ZStream{
 
   public Inflater(int w, boolean nowrap) throws GZIPException {
     super();
+    param_w = w;
+    param_nowrap = nowrap;
     int ret = init(w, nowrap);
     if(ret!=Z_OK)
       throw new GZIPException(ret+": "+msg);
+  }
+
+  void reset() {
+    finished = false;
+    if(param_wrapperType != null){
+      init(param_w, param_wrapperType);
+    }
+    else {
+      init(param_w, param_nowrap);
+    }
   }
 
   private boolean finished = false;

--- a/src/main/java/com/jcraft/jzlib/Inflater.java
+++ b/src/main/java/com/jcraft/jzlib/Inflater.java
@@ -57,10 +57,6 @@ final public class Inflater extends ZStream{
   static final private int Z_BUF_ERROR=-5;
   static final private int Z_VERSION_ERROR=-6;
 
-  private int param_w = -1;
-  private JZlib.WrapperType param_wrapperType = null;
-  private boolean param_nowrap = false;
-
   public Inflater() {
     super();
     init();
@@ -72,8 +68,6 @@ final public class Inflater extends ZStream{
 
   public Inflater(int w, JZlib.WrapperType wrapperType) throws GZIPException {
     super();
-    param_w = w;
-    param_wrapperType = wrapperType;
     int ret = init(w, wrapperType);
     if(ret!=Z_OK)
       throw new GZIPException(ret+": "+msg);
@@ -89,21 +83,9 @@ final public class Inflater extends ZStream{
 
   public Inflater(int w, boolean nowrap) throws GZIPException {
     super();
-    param_w = w;
-    param_nowrap = nowrap;
     int ret = init(w, nowrap);
     if(ret!=Z_OK)
       throw new GZIPException(ret+": "+msg);
-  }
-
-  void reset() {
-    finished = false;
-    if(param_wrapperType != null){
-      init(param_w, param_wrapperType);
-    }
-    else {
-      init(param_w, param_nowrap);
-    }
   }
 
   private boolean finished = false;

--- a/src/main/java/com/jcraft/jzlib/InflaterInputStream.java
+++ b/src/main/java/com/jcraft/jzlib/InflaterInputStream.java
@@ -36,7 +36,7 @@ public class InflaterInputStream extends FilterInputStream {
 
   private boolean closed = false;
 
-  private boolean eof = false;
+  protected boolean eof = false;
 
   private boolean close_in = true;
 

--- a/src/main/java/com/jcraft/jzlib/InflaterInputStream.java
+++ b/src/main/java/com/jcraft/jzlib/InflaterInputStream.java
@@ -36,7 +36,7 @@ public class InflaterInputStream extends FilterInputStream {
 
   private boolean closed = false;
 
-  protected boolean eof = false;
+  private boolean eof = false;
 
   private boolean close_in = true;
 

--- a/src/main/java/com/jcraft/jzlib/ZStream.java
+++ b/src/main/java/com/jcraft/jzlib/ZStream.java
@@ -368,10 +368,8 @@ public class ZStream{
     return msg;
   }
 
-  /**
-   * Those methods are expected to be override by Inflater and Deflater.
-   * In the future, they will become abstract methods.
-   */ 
+  // Those methods are expected to be override by Inflater and Deflater.
+  // In the future, they will become abstract methods.
   public int end(){ return Z_OK; }
   public boolean finished(){ return false; }
 }

--- a/src/test/scala/GZIPIOStreamTest.scala
+++ b/src/test/scala/GZIPIOStreamTest.scala
@@ -90,4 +90,27 @@ class GZIPIOStreamTest extends FlatSpec with BeforeAndAfter with ShouldMatchers 
 
     csIn.getValue() should equal(csOut.getValue)
   }
+
+  behavior of "GZIPInputStream"
+
+  it can "inflate a concatenated gzip stream." in {
+    // echo -n "a" | gzip > data
+    // echo -n "b" | gzip >> data
+    // echo -n "c" | gzip >> data
+    val data =  {
+     val baos1 = new ByteArrayOutputStream
+      List("a", "b", "c").map{s =>
+        val gos = new GZIPOutputStream(baos1)
+        gos.write(s.getBytes);
+        gos.close
+      }
+      baos1.toByteArray
+    }
+
+    val gis = new GZIPInputStream(new ByteArrayInputStream(data))
+    val baos = new ByteArrayOutputStream()
+    gis -> baos
+
+    baos.toByteArray should equal("abc".getBytes)
+  }
 }

--- a/src/test/scala/GZIPIOStreamTest.scala
+++ b/src/test/scala/GZIPIOStreamTest.scala
@@ -26,6 +26,7 @@ class GZIPIOStreamTest extends FlatSpec with BeforeAndAfter with ShouldMatchers 
 
     val comment = "hi"
     val name = "/tmp/foo"
+    val time = System.currentTimeMillis() / 1000
 
     val content = "hello".getBytes
 
@@ -34,6 +35,7 @@ class GZIPIOStreamTest extends FlatSpec with BeforeAndAfter with ShouldMatchers 
 
     gos.setComment(comment)
     gos.setName(name)
+    gos.setModifiedTime(time)
  
     gos.write(content)
     gos.close
@@ -51,6 +53,7 @@ class GZIPIOStreamTest extends FlatSpec with BeforeAndAfter with ShouldMatchers 
 
     comment should equal(gis.getComment)
     name should equal(gis.getName)
+    time should equal(gis.getModifiedTime)
 
     val crc32 = new CRC32
     crc32.update(content, 0, content.length)

--- a/src/test/scala/GZIPIOStreamTest.scala
+++ b/src/test/scala/GZIPIOStreamTest.scala
@@ -87,4 +87,27 @@ class GZIPIOStreamTest extends FlatSpec with BeforeAndAfter with ShouldMatchers 
 
     csIn.getValue() should equal(csOut.getValue)
   }
+
+  behavior of "GZIPInputStream"
+
+  it can "inflate a concatenated gzip stream." in {
+    // echo -n "a" | gzip > data
+    // echo -n "b" | gzip >> data
+    // echo -n "c" | gzip >> data
+    val data =  {
+     val baos1 = new ByteArrayOutputStream
+      List("a", "b", "c").map{s =>
+        val gos = new GZIPOutputStream(baos1)
+        gos.write(s.getBytes);
+        gos.close
+      }
+      baos1.toByteArray
+    }
+
+    val gis = new GZIPInputStream(new ByteArrayInputStream(data))
+    val baos = new ByteArrayOutputStream()
+    gis -> baos
+
+    baos.toByteArray should equal("abc".getBytes)
+  }
 }

--- a/src/test/scala/GZIPIOStreamTest.scala
+++ b/src/test/scala/GZIPIOStreamTest.scala
@@ -90,27 +90,4 @@ class GZIPIOStreamTest extends FlatSpec with BeforeAndAfter with ShouldMatchers 
 
     csIn.getValue() should equal(csOut.getValue)
   }
-
-  behavior of "GZIPInputStream"
-
-  it can "inflate a concatenated gzip stream." in {
-    // echo -n "a" | gzip > data
-    // echo -n "b" | gzip >> data
-    // echo -n "c" | gzip >> data
-    val data =  {
-     val baos1 = new ByteArrayOutputStream
-      List("a", "b", "c").map{s =>
-        val gos = new GZIPOutputStream(baos1)
-        gos.write(s.getBytes);
-        gos.close
-      }
-      baos1.toByteArray
-    }
-
-    val gis = new GZIPInputStream(new ByteArrayInputStream(data))
-    val baos = new ByteArrayOutputStream()
-    gis -> baos
-
-    baos.toByteArray should equal("abc".getBytes)
-  }
 }


### PR DESCRIPTION
Restore previous work on concatenated gzip streams

The code here as-is broke two JRuby tests:

```
  1) Failure:
TestZlibGzipFile#test_gzip_reader_zcat [/home/runner/work/jruby/jruby/test/mri/zlib/test_zlib.rb:594]:
<["foo", "bar"]> expected but was
<["foobar"]>.

  2) Failure:
TestZlibGzipReader#test_unused2 [/home/runner/work/jruby/jruby/test/mri/zlib/test_zlib.rb:960]:
<"aaaa"> expected but was
<"aaaabbbb">.
```

I reverted it for 1.1.5 but preserve the work here.

See https://github.com/ymnk/jzlib/commit/0c1c243f2a1e7546a765e72562c4e09ae27f32ce
for the original branch by @ymnk.
